### PR TITLE
set versioning for npm dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/*
+npm-debug.log
+.DS_Store

--- a/app/views/layouts/default.jade
+++ b/app/views/layouts/default.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en', xmlns='http://www.w3.org/1999/xhtml', xmlns:fb='https://www.facebook.com/2008/fbml', itemscope='itemscope', itemtype='http://schema.org/Product')
   include ../includes/head
   body

--- a/config/express.js
+++ b/config/express.js
@@ -3,7 +3,7 @@
  */
 
 var express = require('express')
-  , mongoStore = require('connect-mongo')(express)
+  , mongoStore = require('connect-mongo/es5')(express)
   , flash = require('connect-flash')
   , helpers = require('view-helpers')
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
       "test": "NODE_ENV=test ./node_modules/.bin/mocha --reporter spec test/test-*.js"
     }
   , "dependencies": {
-      "express": "latest"
+      "express": "3.0.0"
     , "jade": "latest"
     , "mongoose": "latest"
-    , "connect-mongo": "latest"
+    , "connect-mongo": "1.0.0"
     , "connect-flash": "latest"
     , "passport": "latest"
     , "passport-local": "latest"


### PR DESCRIPTION
connect-mongo switched over to ES6 and needs to declare es5 for us. Also parts of express got bundled into its own middleware so switched up to express 3.0. With theses fixes people can fire up the project!
